### PR TITLE
Harden session wallet setup and async NFT loading

### DIFF
--- a/Runtime/codebase/Web3AuthWallet.cs
+++ b/Runtime/codebase/Web3AuthWallet.cs
@@ -174,9 +174,14 @@ namespace Solana.Unity.SDK
 
         public Dictionary<string, LoginConfigItem> BuildLoginConfigDictionary(List<LoginConfig> loginConfigList) {
             if (loginConfigList == null) return null;
-            var dictionary = new Dictionary<string, LoginConfigItem>();
+            var dictionary = new Dictionary<string, LoginConfigItem>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var config in loginConfigList) {
+                if (string.IsNullOrWhiteSpace(config?.name))
+                {
+                    Debug.LogWarning("Skipping Web3Auth login config with empty name.");
+                    continue;
+                }
                 var loginConfigItem = new LoginConfigItem {
                     verifier = config.verifier,
                     typeOfLogin = config.typeOfLogin,
@@ -193,7 +198,7 @@ namespace Solana.Unity.SDK
                     showOnMobile = config.showOnMobile
                 };
 
-                dictionary.Add(config.name, loginConfigItem);
+                dictionary[config.name] = loginConfigItem;
             }
 
             return dictionary;


### PR DESCRIPTION
## Summary
- guard the Web3Auth login config dictionary against duplicate or blank labels
- resolve SessionWallet endpoint lookups, use stable password encoding, and refund via lamport math with RPC null checks
- refactor Web3.LoadNFTs to fetch metadata off the main thread with throttled concurrency before updating listeners

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ce20776ac88320b952150d25d43fe3